### PR TITLE
Fakes and steps for testing events

### DIFF
--- a/events/example_subscriber_test.go
+++ b/events/example_subscriber_test.go
@@ -38,7 +38,7 @@ func ExampleSubscriber() {
 		select {
 		case evt := <-sub.Receive():
 			q := question{}
-			if err := json.Unmarshal(evt, &q); err != nil {
+			if err := json.Unmarshal(evt.Body, &q); err != nil {
 				fmt.Println("Error deserializing event:", err)
 				continue
 			}

--- a/events/integration_test.go
+++ b/events/integration_test.go
@@ -48,7 +48,7 @@ func TestPublishSubscribe(t *testing.T) {
 
 	defer sub.Close()
 
-	messages := [][]byte{}
+	messages := []Event{}
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 	go func() {
@@ -81,12 +81,12 @@ func TestPublishSubscribe(t *testing.T) {
 		return
 	}
 
-	if string(messages[0]) != `{"foo":"bar"}` {
-		t.Errorf("expected first message to be %v, but was %v", `{"foo":"bar"}`, string(messages[0]))
+	if string(messages[0].Body) != `{"foo":"bar"}` {
+		t.Errorf("expected first message to be %v, but was %v", `{"foo":"bar"}`, string(messages[0].Body))
 	}
 
-	if string(messages[1]) != `{"one":1}` {
-		t.Errorf("expected first message to be %v, but was %v", `{"one":1}`, string(messages[1]))
+	if string(messages[1].Body) != `{"one":1}` {
+		t.Errorf("expected first message to be %v, but was %v", `{"one":1}`, string(messages[1].Body))
 	}
 }
 
@@ -114,13 +114,13 @@ func TestReconnection(t *testing.T) {
 		t.Error(err)
 	}
 
-	var evt []byte
+	var evt Event
 
 	// get first event
 	select {
 	case evt = <-sub.Receive():
-		if string(evt) != `"one"` {
-			t.Errorf(`expected "one", but got %v`, string(evt))
+		if string(evt.Body) != `"one"` {
+			t.Errorf(`expected "one", but got %v`, string(evt.Body))
 			return
 		}
 	case <-time.After(50 * time.Millisecond):
@@ -152,8 +152,8 @@ func TestReconnection(t *testing.T) {
 	// get new event
 	select {
 	case evt = <-sub.Receive():
-		if string(evt) != `"two"` {
-			t.Errorf(`expected "two", but got %v`, string(evt))
+		if string(evt.Body) != `"two"` {
+			t.Errorf(`expected "two", but got %v`, string(evt.Body))
 			return
 		}
 	case <-time.After(50 * time.Millisecond):

--- a/testutils/fakes/publisher.go
+++ b/testutils/fakes/publisher.go
@@ -1,0 +1,46 @@
+package fakes
+
+import (
+	"sync"
+
+	"encoding/json"
+	"fmt"
+
+	"github.com/hellomd/go-sdk/events"
+)
+
+// Publisher should be used to fake an event publisher
+type Publisher struct {
+	lock      sync.Mutex
+	published []events.Event
+}
+
+// Publish stores in the publisher instance the events that were published by it
+func (p *Publisher) Publish(key string, body interface{}) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.published == nil {
+		p.published = []events.Event{}
+	}
+
+	marshalled, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("error marshalling body: %v", err)
+	}
+
+	p.published = append(p.published, events.Event{Key: key, Body: marshalled})
+	return nil
+}
+
+// GetPublished returns all the events that were published to the fake publisher instance
+func (p *Publisher) GetPublished() []events.Event {
+	return p.published[:]
+}
+
+var _ publisher = &Publisher{}
+var _ publisher = &events.Publisher{}
+
+type publisher interface {
+	Publish(key string, body interface{}) error
+}

--- a/testutils/fakes/subscription.go
+++ b/testutils/fakes/subscription.go
@@ -1,0 +1,71 @@
+package fakes
+
+import (
+	"sync"
+
+	"github.com/hellomd/go-sdk/events"
+)
+
+// Subscription should be used to simulate receiving a subscribed event
+type Subscription struct {
+	lock    sync.Mutex
+	receive chan events.Event
+	close   chan struct{}
+}
+
+// Receive returns a channel to which fake subscription events are passed
+func (s *Subscription) Receive() <-chan events.Event {
+	s.assert()
+	return s.receive
+}
+
+// NotifyClose notifies of when the subscription ends
+func (s *Subscription) NotifyClose() <-chan struct{} {
+	s.assert()
+	return s.close
+}
+
+// Close stops receiving events for this subscription
+func (s *Subscription) Close() {
+	s.assert()
+	close(s.receive)
+	s.close <- struct{}{}
+}
+
+// Errors does nothing in this fake implementation
+func (s *Subscription) Errors() <-chan error {
+	s.assert()
+	return make(chan error)
+}
+
+// FakeReceive sends an event to the Receive channel
+func (s *Subscription) FakeReceive(key string, body []byte) {
+	s.assert()
+	s.receive <- events.Event{
+		Key:  key,
+		Body: body,
+	}
+}
+
+func (s *Subscription) assert() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.receive == nil {
+		s.receive = make(chan events.Event)
+	}
+
+	if s.close == nil {
+		s.close = make(chan struct{})
+	}
+}
+
+var _ subscription = &Subscription{}
+var _ subscription = &events.Subscription{}
+
+type subscription interface {
+	Receive() <-chan events.Event
+	NotifyClose() <-chan struct{}
+	Close()
+	Errors() <-chan error
+}

--- a/testutils/steps/events.go
+++ b/testutils/steps/events.go
@@ -1,0 +1,62 @@
+package steps
+
+import (
+	"fmt"
+
+	"encoding/json"
+
+	"reflect"
+
+	"github.com/DATA-DOG/godog/gherkin"
+	"github.com/hellomd/go-sdk/testutils"
+	"github.com/hellomd/go-sdk/testutils/fakes"
+)
+
+// TheFollowingEventsShouldHaveBeenPublished checks whether the desired events have been published
+//
+// Usage:
+// Then the following events should have been published
+//   | Key                         | Body                                     |
+//   | questions.article.published | {"id": "abc", "title": "First question"} |
+func TheFollowingEventsShouldHaveBeenPublished(table *gherkin.DataTable, pub *fakes.Publisher) error {
+	expected := testutils.ParseTable(table)
+	actual := pub.GetPublished()
+
+	expectedMaps := []map[string]interface{}{}
+	for _, e := range expected {
+		var body interface{}
+		if err := json.Unmarshal([]byte(e["Body"]), &body); err != nil {
+			return fmt.Errorf("failed to unmarshal expected body: %v", err)
+		}
+
+		eMap := map[string]interface{}{
+			"Key":  e["Key"],
+			"Body": body,
+		}
+		expectedMaps = append(expectedMaps, eMap)
+	}
+
+	actualMaps := []map[string]interface{}{}
+	for _, e := range actual {
+		var body interface{}
+		if err := json.Unmarshal(e.Body, &body); err != nil {
+			return fmt.Errorf("failed to unmarshal actual body: %v", err)
+		}
+
+		eMap := map[string]interface{}{
+			"Key":  e.Key,
+			"Body": body,
+		}
+		actualMaps = append(actualMaps, eMap)
+	}
+
+	if len(expectedMaps) != len(actualMaps) {
+		return fmt.Errorf("expected %v events, but got %v: %v", len(expectedMaps), len(actualMaps), actualMaps)
+	}
+
+	if !reflect.DeepEqual(expectedMaps, actualMaps) {
+		return fmt.Errorf("expected different events to have been published:\n  Expected %v\n  Actual %v", expectedMaps, actualMaps)
+	}
+
+	return nil
+}

--- a/testutils/steps/events_test.go
+++ b/testutils/steps/events_test.go
@@ -1,0 +1,138 @@
+package steps
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/godog/gherkin"
+	"github.com/hellomd/go-sdk/testutils/fakes"
+)
+
+func TestTheFollowingEventsShouldHaveBeenPublished(t *testing.T) {
+	t.Run("pass with two matching events", func(t *testing.T) {
+		// Arrange
+		table := buildTable([][]string{
+			{"Key", "Body"},
+			{"some.key", `"foo"`},
+			{"some.key", `"bar"`},
+		})
+
+		pub := new(fakes.Publisher)
+		pub.Publish("some.key", "foo")
+		pub.Publish("some.key", "bar")
+
+		// Act
+		err := TheFollowingEventsShouldHaveBeenPublished(table, pub)
+
+		// Assert
+		if err != nil {
+			t.Error("unexpected error:", err)
+		}
+	})
+
+	t.Run("pass with one complex json", func(t *testing.T) {
+		// Arrange
+		table := buildTable([][]string{
+			{"Key", "Body"},
+			{"some.key", `{"id": "one", "size": 3}`},
+		})
+
+		pub := new(fakes.Publisher)
+		pub.Publish("some.key", map[string]interface{}{"id": "one", "size": 3})
+
+		// Act
+		err := TheFollowingEventsShouldHaveBeenPublished(table, pub)
+
+		// Assert
+		if err != nil {
+			t.Error("unexpected error:", err)
+		}
+	})
+
+	t.Run("pass with no events", func(t *testing.T) {
+		// Arrange
+		table := buildTable([][]string{{"Key", "Body"}})
+
+		pub := new(fakes.Publisher)
+
+		// Act
+		err := TheFollowingEventsShouldHaveBeenPublished(table, pub)
+
+		// Assert
+		if err != nil {
+			t.Error("unexpected error:", err)
+		}
+	})
+
+	t.Run("fail with fewer events than expected", func(t *testing.T) {
+		// Arrange
+		table := buildTable([][]string{
+			{"Key", "Body"},
+			{"some.key", `"foo"`},
+			{"some.key", `"bar"`},
+		})
+
+		pub := new(fakes.Publisher)
+		pub.Publish("some.key", "foo")
+
+		// Act
+		err := TheFollowingEventsShouldHaveBeenPublished(table, pub)
+
+		// Assert
+		if err == nil {
+			t.Error("expected an error, but got none")
+		}
+	})
+
+	t.Run("fail with more events than expected", func(t *testing.T) {
+		// Arrange
+		table := buildTable([][]string{
+			{"Key", "Body"},
+			{"some.key", `"foo"`},
+		})
+
+		pub := new(fakes.Publisher)
+		pub.Publish("some.key", "foo")
+		pub.Publish("some.key", "bar")
+
+		// Act
+		err := TheFollowingEventsShouldHaveBeenPublished(table, pub)
+
+		// Assert
+		if err == nil {
+			t.Error("expected an error, but got none")
+		}
+	})
+
+	t.Run("fail with one complex json", func(t *testing.T) {
+		// Arrange
+		table := buildTable([][]string{
+			{"Key", "Body"},
+			{"some.key", `{"id": "one", "size": 3}`},
+		})
+
+		pub := new(fakes.Publisher)
+		pub.Publish("some.key", map[string]interface{}{"id": "oh no!", "size": 999})
+
+		// Act
+		err := TheFollowingEventsShouldHaveBeenPublished(table, pub)
+
+		// Assert
+		if err == nil {
+			t.Error("expected an error, but got none")
+		}
+	})
+}
+
+func buildTable(src [][]string) *gherkin.DataTable {
+	tableRows := []*gherkin.TableRow{}
+	for _, row := range src {
+		tableCells := []*gherkin.TableCell{}
+		for _, cell := range row {
+			tableCells = append(tableCells, &gherkin.TableCell{Value: cell})
+		}
+
+		tableRows = append(tableRows, &gherkin.TableRow{Cells: tableCells})
+	}
+
+	return &gherkin.DataTable{Rows: tableRows}
+}


### PR DESCRIPTION
:exclamation: Breaking changes:
* `Receive` now returns `chan Event` instead of `chan []byte`, because a subscribed event's key might be necessary in the case of subscribing to a pattern