### PR TITLE
Require events to be acknowledged or rejected

### DIFF
--- a/events/types.go
+++ b/events/types.go
@@ -1,0 +1,14 @@
+package events
+
+// Acknowledger sends feedback on whether the event has been successfully processed or not
+type Acknowledger interface {
+	Reject(bool)
+	Ack()
+}
+
+// Event is what is received by a subscription
+type Event struct {
+	Acknowledger
+	Key  string
+	Body []byte
+}


### PR DESCRIPTION
Consuming an event should be followed by either:
* `e.Reject(true)` -> reject and requeue should be used this for transient errors, when simply retrying should be enough
* `e.Reject(false)` -> reject without requeuing should be called when a permanent error occurs, whether it is due to a malformed event or invalid operation
* `e.Ack()` -> acknowledge the event when it has been successfully processed