### PR TITLE
Expose function for creating a mongo session without middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:latest
+
 WORKDIR /go/src/github.com/hellomd/go-sdk
 ADD . .
 ENTRYPOINT go test -v $(go list ./... | grep -v /vendor/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,29 @@
-test:
-    build: .
-    dockerfile: Dockerfile
-    environment: 
-        MONGO_URL: mongo_db
-        AMQP_URL: "amqp://guest:guest@rabbit"
-    links: 
-        - mongo_db
-        - rabbit
-mongo_db:
-    image: mongo:3.0.15
-rabbit:
-    image: rabbitmq:3-alpine
+version: '2.1'
+
+services:
+    test:
+        build:
+            context: .
+            dockerfile: Dockerfile
+        environment: 
+            MONGO_URL: mongo_db
+            AMQP_URL: "amqp://guest:guest@rabbit"
+        links: 
+            - mongo_db
+            - rabbit
+
+    mongo_db:
+        image: mongo:3.0.15
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:27017"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
+
+    rabbit:
+        image: rabbitmq
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:5672"]
+            interval: 30s
+            timeout: 10s
+            retries: 5

--- a/mongo/middleware.go
+++ b/mongo/middleware.go
@@ -1,12 +1,7 @@
 package mongo
 
 import (
-	"crypto/tls"
-	"net"
 	"net/http"
-	"net/url"
-	"strings"
-	"time"
 
 	mgo "gopkg.in/mgo.v2"
 )
@@ -17,61 +12,23 @@ type Middleware interface {
 }
 
 type middleware struct {
-	session  *mgo.Session
-	mongoURL *url.URL
+	session *mgo.Session
+	dbName  string
 }
 
 // NewMiddleware -
 func NewMiddleware(mongoURL string, useSSL bool) (Middleware, error) {
-	url, err := url.Parse(mongoURL)
+	s, dbName, err := CreateSession(mongoURL, useSSL)
 	if err != nil {
 		return nil, err
 	}
 
-	s := &mgo.Session{}
-	if useSSL {
-		var err error
-		s, err = createSessionWithSSL(url)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		s, err = mgo.Dial(url.String())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return &middleware{s, url}, nil
+	return &middleware{s, dbName}, nil
 }
 
 func (mw *middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	s := mw.session.Copy()
-	context := SetInCtx(r.Context(), s.DB(strings.TrimPrefix(mw.mongoURL.Path, "/")))
+	context := SetInCtx(r.Context(), s.DB(mw.dbName))
 	next(w, r.WithContext(context))
 	defer s.Close()
-}
-
-func createSessionWithSSL(url *url.URL) (*mgo.Session, error) {
-	info := &mgo.DialInfo{
-		Addrs:    strings.Split(url.Host, ","),
-		Database: strings.TrimPrefix(url.Path, "/"),
-		Timeout:  10 * time.Second,
-	}
-
-	if url.User != nil {
-		info.Username = url.User.Username()
-		info.Password, _ = url.User.Password()
-	}
-
-	info.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
-		return tls.Dial("tcp", addr.String(), &tls.Config{})
-	}
-
-	s, err := mgo.DialWithInfo(info)
-	if err != nil {
-		return nil, err
-	}
-
-	return s, nil
 }

--- a/mongo/middleware_test.go
+++ b/mongo/middleware_test.go
@@ -3,7 +3,6 @@ package mongo
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/hellomd/go-sdk/config"
@@ -38,13 +37,12 @@ func test(mdw Middleware, t *testing.T) {
 	a.Use(mw)
 
 	a.Use(negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-		dbName := strings.TrimPrefix(mw.mongoURL.Path, "/")
 		v, err := GetFromCtx(r.Context())
 		if err == errNotInCtx {
 			t.Error("Expected database on context")
 		}
-		if v.Name != dbName {
-			t.Errorf("Expected %s database name, got: %s", v.Name, dbName)
+		if v.Name != mw.dbName {
+			t.Errorf("Expected %s database name, got: %s", v.Name, mw.dbName)
 		}
 		if v.Session == mw.session {
 			t.Errorf("Expected session to be different from stored session")

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -1,0 +1,59 @@
+package mongo
+
+import (
+	"crypto/tls"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	mgo "gopkg.in/mgo.v2"
+)
+
+// CreateSession returns a new mongo session and its DB name
+func CreateSession(mongoURL string, useSSL bool) (*mgo.Session, string, error) {
+	url, err := url.Parse(mongoURL)
+	if err != nil {
+		return nil, "", err
+	}
+
+	s := &mgo.Session{}
+	if useSSL {
+		var err error
+		s, err = createSessionWithSSL(url)
+		if err != nil {
+			return nil, "", err
+		}
+	} else {
+		s, err = mgo.Dial(url.String())
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	return s, strings.TrimPrefix(url.Path, "/"), nil
+}
+
+func createSessionWithSSL(url *url.URL) (*mgo.Session, error) {
+	info := &mgo.DialInfo{
+		Addrs:    strings.Split(url.Host, ","),
+		Database: strings.TrimPrefix(url.Path, "/"),
+		Timeout:  10 * time.Second,
+	}
+
+	if url.User != nil {
+		info.Username = url.User.Username()
+		info.Password, _ = url.User.Password()
+	}
+
+	info.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
+		return tls.Dial("tcp", addr.String(), &tls.Config{})
+	}
+
+	s, err := mgo.DialWithInfo(info)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}


### PR DESCRIPTION
Other parts of services, such as a worker, need the same logic that the middleware uses for creating a Mongo session. This PR exposes a function for doing so.