### PR TITLE
Use context for storing service authentication token

### DIFF
--- a/authentication/context.go
+++ b/authentication/context.go
@@ -6,6 +6,7 @@ import (
 )
 
 type ctxKey struct{}
+type serviceTokenCtxKey struct{}
 
 var errNoUserInCtx = errors.New("no user in context")
 
@@ -21,4 +22,19 @@ func GetUserFromCtx(ctx context.Context) *User {
 // SetUserInCtx -
 func SetUserInCtx(ctx context.Context, user *User) context.Context {
 	return context.WithValue(ctx, ctxKey{}, user)
+}
+
+// GetServiceTokenFromCtx gets a previously stored service authentication token from the context
+func GetServiceTokenFromCtx(ctx context.Context) string {
+	t, ok := ctx.Value(serviceTokenCtxKey{}).(string)
+	if !ok {
+		panic("no service token in context")
+	}
+
+	return t
+}
+
+// SetServiceTokenInCtx sets a service authentication token in a new context and returns it
+func SetServiceTokenInCtx(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, serviceTokenCtxKey{}, token)
 }

--- a/authentication/current_user.go
+++ b/authentication/current_user.go
@@ -5,7 +5,7 @@ type User struct {
 	ID        string `json:"id"`
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
-	Service   string `json:"service"`
+	IsService   bool `json:"isService"`
 }
 
 // Empty -

--- a/authentication/current_user.go
+++ b/authentication/current_user.go
@@ -5,7 +5,7 @@ type User struct {
 	ID        string `json:"id"`
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
-	IsService   bool `json:"isService"`
+	IsService *bool  `json:"isService,omitempty"`
 }
 
 // Empty -

--- a/authentication/middleware.go
+++ b/authentication/middleware.go
@@ -42,11 +42,13 @@ func NewMiddleware(secret []byte) func(w http.ResponseWriter, r *http.Request, n
 
 		ctx := r.Context()
 
+		isService := new(bool)
+		*isService = true
 		serviceToken, err := tokenCreator.CreateAccessTkn(&TokenExtraClaims{
 			ID:        user.ID,
 			FirstName: user.FirstName,
 			LastName:  user.LastName,
-			IsService: true,
+			IsService: isService,
 		}, time.Now().Add(1*time.Hour))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/authentication/middleware.go
+++ b/authentication/middleware.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 )
@@ -14,6 +15,7 @@ var errInvalidHeader = errors.New("invalid authorization header")
 
 // NewMiddleware -
 func NewMiddleware(secret []byte) func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	tokenCreator := NewTokenCreator(secret)
 	validateJWT := func(token *jwt.Token) (interface{}, error) {
 		return secret, nil
 	}
@@ -36,8 +38,22 @@ func NewMiddleware(secret []byte) func(w http.ResponseWriter, r *http.Request, n
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return
 			}
-
 		}
-		next(w, r.WithContext(SetUserInCtx(r.Context(), user)))
+
+		ctx := r.Context()
+
+		serviceToken, err := tokenCreator.CreateAccessTkn(&TokenExtraClaims{
+			ID:        user.ID,
+			FirstName: user.FirstName,
+			LastName:  user.LastName,
+			IsService: true,
+		}, time.Now().Add(1*time.Hour))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		ctx = SetServiceTokenInCtx(ctx, serviceToken)
+		next(w, r.WithContext(SetUserInCtx(ctx, user)))
 	}
 }

--- a/authentication/token_creator.go
+++ b/authentication/token_creator.go
@@ -11,7 +11,7 @@ type TokenExtraClaims struct {
 	ID        string `json:"id"`
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
-	IsService bool   `json:"isService"`
+	IsService *bool  `json:"isService,omitempty"`
 }
 
 type claims struct {

--- a/authentication/token_creator.go
+++ b/authentication/token_creator.go
@@ -11,7 +11,7 @@ type TokenExtraClaims struct {
 	ID        string `json:"id"`
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
-	Service   string `json:"service"`
+	IsService bool   `json:"isService"`
 }
 
 type claims struct {


### PR DESCRIPTION
This will allow a simple client to, instead of having to use the `TokenCreator` directly, simply call `authentication.GetServiceTokenFromCtx(ctx)` to get a valid service token.