### PR TITLE
Create event middleware for logging

### DIFF
--- a/events/authentication/middleware.go
+++ b/events/authentication/middleware.go
@@ -12,7 +12,7 @@ func NewMiddleware(secret []byte) func(context.Context, *events.Event, events.Ha
 	return func(ctx context.Context, event *events.Event, next events.HandlerFunc) {
 		ctx, err := ctxAuth(ctx, event.Header[authentication.HeaderKey])
 		if err != nil {
-			event.Reject(false)
+			event.Reject(false, err)
 			return
 		}
 

--- a/events/logger/middleware.go
+++ b/events/logger/middleware.go
@@ -1,0 +1,90 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hellomd/go-sdk/events"
+	"github.com/hellomd/go-sdk/logger"
+	"github.com/hellomd/go-sdk/requestid"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	statusAcked    = "acked"
+	statusRequeued = "requeued"
+	statusRejected = "rejected"
+)
+
+var _ events.Acknowledger = &loggerAcknowledger{}
+
+func NewMiddleware(appName, env string, instance *logrus.Logger) events.PipelineHandlerFunc {
+	return func(ctx context.Context, e *events.Event, next events.HandlerFunc) {
+		start := time.Now()
+		requestID := ctx.Value(requestid.RequestIDCtxKey)
+
+		entry := logrus.NewEntry(instance)
+		entry = entry.WithFields(logrus.Fields{
+			"request_id":       requestID,
+			"event_key":        e.Key,
+			"application_name": appName,
+			"environment":      env,
+		})
+
+		ack := &loggerAcknowledger{inner: e.Acknowledger}
+		ew := *e
+		ew.Acknowledger = ack
+
+		next(logger.SetInCtx(ctx, entry), &ew)
+
+		latency := time.Since(start)
+		message := fmt.Sprintf("evt %v | %v | %v", e.Key, latency, ack.status)
+		entry = entry.WithFields(logrus.Fields{
+			"took":   latency,
+			"status": ack.status,
+		})
+
+		switch ack.status {
+		case statusRequeued:
+			entry.WithField("error", fmt.Sprint(ack.err)).Warn(fmt.Sprintf(`%v "%v"`, message, ack.err))
+
+		case statusRejected:
+			entry.WithField("error", fmt.Sprint(ack.err)).Error(fmt.Sprintf(`%v "%v"`, message, ack.err))
+
+		default:
+			entry.Info(message)
+		}
+	}
+}
+
+type loggerAcknowledger struct {
+	inner  events.Acknowledger
+	status string
+	err    error
+}
+
+func (a *loggerAcknowledger) Reject(requeue bool, err error) {
+	a.inner.Reject(requeue, err)
+	if a.status != "" {
+		return
+	}
+
+	a.err = err
+
+	if requeue {
+		a.status = statusRequeued
+		return
+	}
+
+	a.status = statusRejected
+}
+
+func (a *loggerAcknowledger) Ack() {
+	a.inner.Ack()
+	if a.status != "" {
+		return
+	}
+
+	a.status = statusAcked
+}

--- a/events/logger/middleware.go
+++ b/events/logger/middleware.go
@@ -17,8 +17,6 @@ const (
 	statusRejected = "rejected"
 )
 
-var _ events.Acknowledger = &loggerAcknowledger{}
-
 func NewMiddleware(appName, env string, instance *logrus.Logger) events.PipelineHandlerFunc {
 	return func(ctx context.Context, e *events.Event, next events.HandlerFunc) {
 		start := time.Now()

--- a/events/logger/middleware_test.go
+++ b/events/logger/middleware_test.go
@@ -1,0 +1,186 @@
+package logger
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/hellomd/go-sdk/events"
+	"github.com/sirupsen/logrus"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type testFormatter struct {
+	logCalls int
+	entry    *logrus.Entry
+}
+
+func (f *testFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	f.logCalls++
+	f.entry = entry
+	return []byte{}, nil
+}
+
+func ShouldLastWithin(actual interface{}, expected ...interface{}) string {
+	const wrongArgs = "You must provide two durations as arguments for this assertion."
+	if len(expected) != 2 {
+		return wrongArgs
+	}
+
+	actualDuration, okActual := actual.(time.Duration)
+	expectedDuration, okExpected := expected[0].(time.Duration)
+	margin, okMargin := expected[1].(time.Duration)
+
+	if !okActual || !okExpected || !okMargin {
+		return wrongArgs
+	}
+
+	if actualDuration < expectedDuration-margin || actualDuration > expectedDuration+margin {
+		return fmt.Sprintf("Expected '%v' to last '%v' give or take '%v' (but it didn't)!",
+			actualDuration, expectedDuration, margin)
+	}
+
+	return ""
+}
+
+func TestMiddleware(t *testing.T) {
+	Convey("logger middleware", t, func() {
+		formatter := new(testFormatter)
+
+		m := NewMiddleware("myapp", "someenv", func() *logrus.Logger {
+			logger := logrus.New()
+			logger.Formatter = formatter
+			logger.Out = ioutil.Discard
+			return logger
+		}())
+
+		ctx := context.Background()
+		e := &events.Event{
+			Acknowledger: new(fakeAcknowledger),
+			Key:          "foo.bar",
+		}
+
+		Convey("any handling", func() {
+			m(ctx, e, func(ctx context.Context, e *events.Event) {
+				time.Sleep(15 * time.Millisecond)
+			})
+
+			Convey("should log with correct message and fields", func() {
+				So(formatter.logCalls, ShouldEqual, 1)
+				latency := formatter.entry.Data["took"].(time.Duration)
+				So(latency, ShouldLastWithin, 15*time.Millisecond, 2*time.Millisecond)
+
+				So(formatter.entry.Message, ShouldStartWith, fmt.Sprintf("evt foo.bar | %v | ", latency))
+				So(formatter.entry.Data, ShouldResemble, logrus.Fields{
+					"request_id":       nil,
+					"event_key":        "foo.bar",
+					"application_name": "myapp",
+					"environment":      "someenv",
+					"took":             latency,
+					"status":           "",
+				})
+			})
+		})
+
+		Convey("acknowledge event", func() {
+			m(ctx, e, func(ctx context.Context, e *events.Event) {
+				e.Ack()
+			})
+
+			So(formatter.logCalls, ShouldEqual, 1)
+			So(formatter.entry.Message, ShouldEndWith, "| "+statusAcked)
+			So(formatter.entry.Data["status"], ShouldEqual, statusAcked)
+		})
+
+		Convey("reject event", func() {
+			m(ctx, e, func(ctx context.Context, e *events.Event) {
+				e.Reject(false, errors.New("some error"))
+			})
+
+			So(formatter.logCalls, ShouldEqual, 1)
+			So(formatter.entry.Message, ShouldEndWith, "| "+statusRejected+` "some error"`)
+			So(formatter.entry.Data["status"], ShouldEqual, statusRejected)
+			So(formatter.entry.Data["error"], ShouldEqual, "some error")
+		})
+
+		Convey("reject and requeue event", func() {
+			m(ctx, e, func(ctx context.Context, e *events.Event) {
+				e.Reject(true, errors.New("some error"))
+			})
+
+			So(formatter.logCalls, ShouldEqual, 1)
+			So(formatter.entry.Message, ShouldEndWith, "| "+statusRequeued+` "some error"`)
+			So(formatter.entry.Data["status"], ShouldEqual, statusRequeued)
+			So(formatter.entry.Data["error"], ShouldEqual, "some error")
+		})
+	})
+}
+
+func TestAcknowledger(t *testing.T) {
+	Convey("logger acknowledger", t, func() {
+		inner := new(fakeAcknowledger)
+		a := &loggerAcknowledger{inner: inner}
+
+		Convey("reject and requeue", func() {
+			err := errors.New("nope")
+			a.Reject(true, err)
+
+			Convey("status should be requeued", func() {
+				So(a.status, ShouldEqual, statusRequeued)
+				So(a.err, ShouldEqual, err)
+			})
+
+			Convey("underlying acknowledger should be called", func() {
+				So(inner.rejected, ShouldBeTrue)
+				So(inner.requeued, ShouldBeTrue)
+				So(inner.err, ShouldEqual, err)
+			})
+		})
+
+		Convey("reject without requeuing", func() {
+			err := errors.New("nope")
+			a.Reject(false, err)
+
+			Convey("status should be rejected", func() {
+				So(a.status, ShouldEqual, statusRejected)
+				So(a.err, ShouldEqual, err)
+			})
+
+			Convey("underlying acknowledger should be called", func() {
+				So(inner.rejected, ShouldBeTrue)
+				So(inner.requeued, ShouldBeFalse)
+				So(inner.err, ShouldEqual, err)
+			})
+		})
+
+		Convey("acknowledge", func() {
+			a.Ack()
+
+			Convey("status should be acked", func() {
+				So(a.status, ShouldEqual, statusAcked)
+			})
+
+			Convey("underlying acknowledger should be called", func() {
+				So(inner.acked, ShouldBeTrue)
+			})
+		})
+	})
+}
+
+type fakeAcknowledger struct {
+	acked, rejected, requeued bool
+	err                       error
+}
+
+func (a *fakeAcknowledger) Reject(requeue bool, err error) {
+	a.rejected = true
+	a.requeued = requeue
+	a.err = err
+}
+
+func (a *fakeAcknowledger) Ack() {
+	a.acked = true
+}

--- a/events/subscription.go
+++ b/events/subscription.go
@@ -146,7 +146,7 @@ type acknowledger struct {
 	delivery *amqp.Delivery
 }
 
-func (a *acknowledger) Reject(requeue bool) {
+func (a *acknowledger) Reject(requeue bool, _ error) {
 	a.delivery.Reject(requeue)
 }
 

--- a/events/types.go
+++ b/events/types.go
@@ -6,7 +6,7 @@ import (
 
 // Acknowledger sends feedback on whether the event has been successfully processed or not
 type Acknowledger interface {
-	Reject(bool)
+	Reject(bool, error)
 	Ack()
 }
 


### PR DESCRIPTION
This PR creates a middleware much like `go-sdk/logger` that adds a preconfigured `*logrus.Entry` to the context and, after processing an event, logs the result.

To be able to log an error message, I added an `error` parameter the signature of [`events.Acknowledger::Reject`](https://github.com/hellomd/go-sdk/compare/feature/event-logger?expand=1#diff-cf5959e8e71266ec94d538654c859f83R9). This is a dubious choice, since I basically altered the interface in order to support a specific scenario. Please weigh in on whether you think this is ok or not!