### PR TITLE
Prioritize published events

### DIFF
--- a/events/subscriber.go
+++ b/events/subscriber.go
@@ -14,7 +14,7 @@ const (
 // This subscriber is concurrent safe and has no initialization logic.
 // Feel free to use whatever lifecycle you think is best for it.
 func NewSubscriber(name, amqpURL string, logger *logrus.Logger) *Subscriber {
-	return &Subscriber{name, amqpURL, logger, defaultConcurrency, ExchangeName}
+	return &Subscriber{name, amqpURL, logger, defaultConcurrency, ExchangeName, 0}
 }
 
 // Subscriber is a client that can subscribe to events
@@ -24,12 +24,14 @@ type Subscriber struct {
 	logger      *logrus.Logger
 	Concurrency int
 	Exchange    string
+	MaxPriority    uint8
 }
 
 // Subscribe creates a new subscription for receiving events with keys that match the given pattern
 func (s *Subscriber) Subscribe(pattern string) (*Subscription, error) {
 	sub := &Subscription{
 		exchange:       s.Exchange,
+		maxPriority:       s.MaxPriority,
 		subscriberName: s.name,
 		amqpURL:        s.amqpURL,
 		pattern:        pattern,

--- a/events/subscription.go
+++ b/events/subscription.go
@@ -62,7 +62,8 @@ func (s *Subscription) init() (*amqp.Channel, <-chan amqp.Delivery, error) {
 		return nil, nil, fmt.Errorf("error opening AMQP channel: %v", err)
 	}
 
-	if _, err := ch.QueueDeclare(queueName, durable, autoDelete, exclusive, noWait, nil); err != nil {
+	queueArgs := amqp.Table{"x-max-priority": 1}
+	if _, err := ch.QueueDeclare(queueName, durable, autoDelete, exclusive, noWait, queueArgs); err != nil {
 		return nil, nil, fmt.Errorf("error declaring queue: %v", err)
 	}
 

--- a/events/subscription.go
+++ b/events/subscription.go
@@ -11,6 +11,7 @@ import (
 // Subscription can receive events to which it subscribes
 type Subscription struct {
 	exchange       string
+	maxPriority    uint8
 	subscriberName string
 	amqpURL        string
 	pattern        string
@@ -62,7 +63,10 @@ func (s *Subscription) init() (*amqp.Channel, <-chan amqp.Delivery, error) {
 		return nil, nil, fmt.Errorf("error opening AMQP channel: %v", err)
 	}
 
-	queueArgs := amqp.Table{"x-max-priority": 1}
+	var queueArgs amqp.Table
+	if s.maxPriority > 0 {
+		queueArgs = amqp.Table{"x-max-priority": s.maxPriority}
+	}
 	if _, err := ch.QueueDeclare(queueName, durable, autoDelete, exclusive, noWait, queueArgs); err != nil {
 		return nil, nil, fmt.Errorf("error declaring queue: %v", err)
 	}


### PR DESCRIPTION
This will give by published events a default priority of `1` and make subscriber queues respect that priority. Events meant for reindexing will have to be published with priority `0`.

The default max priority for queues is `0`, so that nothing gets automatically broken with the update. The max priority for the indexer queue will have to be `1`.